### PR TITLE
Enqueue multiple caption lines and continue in certian paused states

### DIFF
--- a/Assets/Unity/Prefabs/HUD.prefab
+++ b/Assets/Unity/Prefabs/HUD.prefab
@@ -34,11 +34,11 @@ RectTransform:
   m_Children:
   - {fileID: 3041055547706185461}
   - {fileID: 716538318345165391}
+  - {fileID: 224536965216652210}
+  - {fileID: 1552835380659510529}
   - {fileID: 5291923441524051351}
   - {fileID: 8047395583892976564}
   - {fileID: 7340658226679339835}
-  - {fileID: 224536965216652210}
-  - {fileID: 1552835380659510529}
   - {fileID: 4190757284014826}
   - {fileID: 224029652108021310}
   m_Father: {fileID: 0}
@@ -1188,6 +1188,8 @@ MonoBehaviour:
   BaseScale: 1
   OscillationSpeed: 4
   OscillationScale: 0.05
+  XAxis: 1
+  YAxis: 1
 --- !u!1 &6293135463504969935
 GameObject:
   m_ObjectHideFlags: 0
@@ -1225,7 +1227,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -62.5}
-  m_SizeDelta: {x: 162.44, y: 15}
+  m_SizeDelta: {x: 167.07, y: 15}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &6747274513052891112
 CanvasRenderer:

--- a/Assets/Unity/Prefabs/HUD/Caption Line.prefab
+++ b/Assets/Unity/Prefabs/HUD/Caption Line.prefab
@@ -387,7 +387,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1554689521562973622, guid: d44c370bc297b42ecb0bac5ebaf34dc8,
         type: 3}
-      propertyPath: PauseWhenNotPlaying
+      propertyPath: Pausable
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3895571317138567579, guid: d44c370bc297b42ecb0bac5ebaf34dc8,

--- a/Assets/Unity/Prefabs/Inspectable.prefab
+++ b/Assets/Unity/Prefabs/Inspectable.prefab
@@ -176,7 +176,7 @@ MonoBehaviour:
     Text: Hmm, it's locked
     VoiceLineKey: 
     Duration: 1
-    DoNotPauseWhenNotPlaying: 0
+    IgnorePause: 0
     DialogueMusicFadeBehaviour:
       EnterBehaviour: 1
       ExitBehaviour: 0

--- a/Assets/Unity/Prefabs/Level Essentials.prefab
+++ b/Assets/Unity/Prefabs/Level Essentials.prefab
@@ -1170,7 +1170,7 @@ PrefabInstance:
     - target: {fileID: 1280701673831173212, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 104.07
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1280701673831173212, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
@@ -1355,7 +1355,7 @@ PrefabInstance:
     - target: {fileID: 4706342347603221291, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 153.57
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4706342347603221291, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
@@ -1420,7 +1420,7 @@ PrefabInstance:
     - target: {fileID: 5484205232242461830, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 99.57
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5484205232242461830, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
@@ -1515,7 +1515,7 @@ PrefabInstance:
     - target: {fileID: 7913260233035610828, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 189.57
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7913260233035610828, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
@@ -1540,7 +1540,7 @@ PrefabInstance:
     - target: {fileID: 8805420024808595057, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 99.57
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8805420024808595057, guid: 185784beef2224b11a285ffa14ebe05e,
         type: 3}

--- a/Assets/Unity/Prefabs/Pixie.prefab
+++ b/Assets/Unity/Prefabs/Pixie.prefab
@@ -2699,7 +2699,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1554689521562973622, guid: d44c370bc297b42ecb0bac5ebaf34dc8,
         type: 3}
-      propertyPath: PauseWhenNotPlaying
+      propertyPath: Pausable
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3895571317138567579, guid: d44c370bc297b42ecb0bac5ebaf34dc8,

--- a/Assets/Unity/Prefabs/PlaySound.prefab
+++ b/Assets/Unity/Prefabs/PlaySound.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   PlayOnStart: 0
   DefaultProgrammerInstrumentKey: 
   EventEmitter: {fileID: 3895571317138567579}
-  PauseWhenNotPlaying: 0
+  Pausable: 0
   OnPlay:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Unity/Prefabs/Training Game/Holoring.prefab
+++ b/Assets/Unity/Prefabs/Training Game/Holoring.prefab
@@ -316,7 +316,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1554689521562973622, guid: d44c370bc297b42ecb0bac5ebaf34dc8,
         type: 3}
-      propertyPath: PauseWhenNotPlaying
+      propertyPath: Pausable
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1554689521562973622, guid: d44c370bc297b42ecb0bac5ebaf34dc8,

--- a/Assets/Unity/Scenes/Training Game Tower Scene.unity
+++ b/Assets/Unity/Scenes/Training Game Tower Scene.unity
@@ -952,7 +952,7 @@ MonoBehaviour:
       tyranny that is terrorising this country. It must be stopped.'
     VoiceLineKey: Voice/Training/Tower
     Duration: 10
-    DoNotPauseWhenNotPlaying: 1
+    IgnorePause: 1
     DialogueMusicFadeBehaviour:
       EnterBehaviour: 2
       ExitBehaviour: 2

--- a/Assets/Unity/Scenes/Training Room 5.unity
+++ b/Assets/Unity/Scenes/Training Room 5.unity
@@ -592,7 +592,7 @@ MonoBehaviour:
     Text: <color=#ff0000>Mr Mentoe</color>
     VoiceLineKey: Voice/Training/R5/3
     Duration: 2.15
-    DoNotPauseWhenNotPlaying: 1
+    IgnorePause: 1
     DialogueMusicFadeBehaviour:
       EnterBehaviour: 2
       ExitBehaviour: 2
@@ -3261,7 +3261,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5130155323799688325, guid: 355d3d9f32d464463883a5572f6fa988,
         type: 3}
-      propertyPath: CaptionLine.DoNotPauseWhenNotPlaying
+      propertyPath: CaptionLine.IgnorePause
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5130155323799688325, guid: 355d3d9f32d464463883a5572f6fa988,
@@ -9509,7 +9509,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1554689521562973622, guid: d44c370bc297b42ecb0bac5ebaf34dc8,
         type: 3}
-      propertyPath: PauseWhenNotPlaying
+      propertyPath: Pausable
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3895571317138567579, guid: d44c370bc297b42ecb0bac5ebaf34dc8,

--- a/Assets/src/AccessTerminalSprite.cs
+++ b/Assets/src/AccessTerminalSprite.cs
@@ -21,11 +21,11 @@ public class AccessTerminalSprite : AInspectable {
 
     LevelObjectives.UsedAccessTerminal = true;
     LoreItemData.RecordRead(Config.LoreItem);
-    StateManager.AddState(State.NotPlaying);
+    StateManager.AddState(State.NotPlayingContinueSounds);
 
     AccessTerminalManager.Current.Open(Config, () => {
       LoreManager.Current.Open(Config.LoreItem, () => {
-        StateManager.RemoveState(State.NotPlaying);
+        StateManager.RemoveState(State.NotPlayingContinueSounds);
       });
     });
   }

--- a/Assets/src/CaptionLine.cs
+++ b/Assets/src/CaptionLine.cs
@@ -7,7 +7,7 @@ public class CaptionLine {
   [TextArea] public string Text;
   public string VoiceLineKey;
   public float Duration;
-  public bool DoNotPauseWhenNotPlaying = false;
+  public bool IgnorePause = false;
 
   public DialogueMusicFadeBehaviour DialogueMusicFadeBehaviour = new DialogueMusicFadeBehaviour(
     DialogueMusicFadeBehaviour.BehaviourType.FadeDown,

--- a/Assets/src/CaptionLineManager.cs
+++ b/Assets/src/CaptionLineManager.cs
@@ -13,9 +13,10 @@ public class CaptionLineManager : MonoBehaviour {
   public TMP_Text BackgroundText, Text;
 
   private CaptionLine CaptionLine = null;
+  private Queue<CaptionLine> CaptionLineQueue = new();
   private bool Running;
-  private Func<float> GetTime;
   private float StartTime;
+  private float CurrentTime;
 
   void Awake() {
     if (SingletonInstance)
@@ -25,20 +26,23 @@ public class CaptionLineManager : MonoBehaviour {
   }
 
   public void Play(CaptionLine captionLine) {
+    if (Running) {
+      if (captionLine != CaptionLine && !CaptionLineQueue.Contains(captionLine)) {
+        CaptionLineQueue.Enqueue(captionLine);
+      }
+      return;
+    }
+
     CaptionLine = captionLine;
 
     SetText(CaptionLine.Text);
 
     if (CaptionLine.HasAudioClip()) {
-      PlaySound.Play(CaptionLine.VoiceLineKey, doNotPause: CaptionLine.DoNotPauseWhenNotPlaying);
+      PlaySound.Play(CaptionLine.VoiceLineKey, doNotPause: CaptionLine.IgnorePause);
     }
 
-    GetTime = CaptionLine.DoNotPauseWhenNotPlaying
-      ? () => Time.time
-      : () => PlayingTime.time;
-
     Running = true;
-    StartTime = GetTime();
+    StartTime = CurrentTime;
 
     CaptionLine.DialogueMusicFadeBehaviour.ApplyEnterBehaviour();
   }
@@ -47,7 +51,9 @@ public class CaptionLineManager : MonoBehaviour {
     if (!Running)
       return;
 
-    float time = GetTime() - StartTime;
+    UpdateTime();
+
+    float time = CurrentTime - StartTime;
 
     if (time < FadeInDuration) {
       SetOpacity(time / FadeInDuration);
@@ -61,6 +67,18 @@ public class CaptionLineManager : MonoBehaviour {
       Running = false;
       SetOpacity(0);
       CaptionLine.DialogueMusicFadeBehaviour.ApplyExitBehaviour();
+      PlayEnqueued();
+    }
+  }
+
+  void UpdateTime() {
+    if (
+      Running && (
+        CaptionLine.IgnorePause ||
+        !StateManager.Enabled(StateFeatures.PauseSounds)
+      )
+    ) {
+      CurrentTime += Time.deltaTime;
     }
   }
 
@@ -71,5 +89,11 @@ public class CaptionLineManager : MonoBehaviour {
 
   void SetOpacity(float opacity) {
     BackgroundText.color = Text.color = new Color(1, 1, 1, opacity);
+  }
+
+  void PlayEnqueued() {
+    if (CaptionLineQueue.Count > 0) {
+      Play(CaptionLineQueue.Dequeue());
+    }
   }
 }

--- a/Assets/src/PlaySound.cs
+++ b/Assets/src/PlaySound.cs
@@ -7,13 +7,13 @@ public class PlaySound : MonoBehaviour {
   public bool PlayOnStart = false;
   public string DefaultProgrammerInstrumentKey = "";
   public FMODUnity.StudioEventEmitter EventEmitter;
-  public bool PauseWhenNotPlaying = false;
+  public bool Pausable = false;
   public UnityEvent OnPlay;
 
   public FMOD.Studio.EventInstance EventInstance => EventEmitter.EventInstance;
 
   private ProgrammerInstrumentUtils ProgrammerInstrumentUtils;
-  private bool OverridePauseWhenNotPlaying = false;
+  private bool OverridePausable = false;
 
   void Start() {
     PreloadProgrammerSounds.PreloadSound(DefaultProgrammerInstrumentKey);
@@ -24,9 +24,12 @@ public class PlaySound : MonoBehaviour {
       Play();
     }
 
-    if (PauseWhenNotPlaying) {
+    if (Pausable) {
       StateManager.AddListener(() => {
-        EventInstance.setPaused(!OverridePauseWhenNotPlaying && !StateManager.Playing);
+        EventInstance.setPaused(
+          !OverridePausable &&
+          StateManager.Enabled(StateFeatures.PauseSounds)
+        );
       });
     }
   }
@@ -49,7 +52,7 @@ public class PlaySound : MonoBehaviour {
   }
 
   public void Play(string programmerInstrumentKey, bool doNotPause) {
-    OverridePauseWhenNotPlaying = doNotPause;
+    OverridePausable = doNotPause;
     Play(programmerInstrumentKey);
   }
 

--- a/Assets/src/StateManager.cs
+++ b/Assets/src/StateManager.cs
@@ -12,12 +12,14 @@ public enum StateFeatures {
   BackgroundAnimations = 2,
   Movement = 4,
   PlayerDeathAnimation = 8,
-  MuffleSounds = 16
+  MuffleSounds = 16,
+  PauseSounds = 32
 };
 
 public enum State {
   Playing,
   NotPlaying,
+  NotPlayingContinueSounds,
   ScriptedMovement,
   Paused,
   PlayerDying
@@ -32,10 +34,15 @@ public class StateManager : MonoBehaviour {
     StateFeatures.None
   );
 
-  static (StateFeatures Enabled, StateFeatures Disabled) NotPlayingState = (
+  static (StateFeatures Enabled, StateFeatures Disabled) NotPlayingContinueSoundsState = (
     StateFeatures.None,
     StateFeatures.Playing | StateFeatures.Movement
   );
+
+  static (StateFeatures Enabled, StateFeatures Disabled) NotPlayingState = InheritFrom(NotPlayingContinueSoundsState, (
+    StateFeatures.PauseSounds,
+    StateFeatures.None
+  ));
 
   static (StateFeatures Enabled, StateFeatures Disabled) ScriptedMovementState = (
     StateFeatures.Movement,
@@ -59,6 +66,9 @@ public class StateManager : MonoBehaviour {
 
       case State.NotPlaying:
         return NotPlayingState;
+
+      case State.NotPlayingContinueSounds:
+        return NotPlayingContinueSoundsState;
 
       case State.ScriptedMovement:
         return ScriptedMovementState;


### PR DESCRIPTION
OP#978

- Fix: When opening access terminal, caption line is paused and resumes when finished. This is disorienting and can cause issues since the access terminal will produce its own caption line. Instead, continue caption line while access terminal is open. This is done with a new `NotPlayingContinueSounds` state; the default `NotPlaying` state (such as dialogue and pausing the game) continues to pause and resume caption lines.
- Show caption line UI on top of the access terminal.
- When playing multiple caption lines at once, queue them. Reject any caption lines that are already playing or have already been queued.
