### PR TITLE
Find files using a specific method on a given class

### DIFF
--- a/usage_data.rb
+++ b/usage_data.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module UsageData
   DO_NOT_SEARCH_DIRS = %w[vendor Plugins]
   GUID_REFERENCING_EXTENSIONS = %w[.unity .prefab .mat .asset .controller]
-  IDENTIFIER_REFERENCING_EXTENSIONS = %w[.cs]
+  IDENTIFIER_REFERENCING_EXTENSIONS = %w[.cs .unity .prefab]
   IGNORE_UNUSED_EXTENSIONS = %w[.unity .preset .otf .ttf .asset .txt .asmdef]
   IGNORE_UNUSED_DIRS = %w[Assets/test/]
 

--- a/used_by.rb
+++ b/used_by.rb
@@ -1,17 +1,33 @@
 require_relative 'usage_data'
 
-input_path = ARGV[0] || raise('Usage: ruby used_by.rb <path>')
-raise "error: #{input_path} does not exist" unless File.exist?(input_path)
-basename = File.basename(input_path)
+path = ARGV[0] || raise('Usage: ruby used_by.rb <path> [method]')
+method_name = ARGV[1]
+raise "error: #{path} does not exist" unless File.exist?(path)
+basename = File.basename(path)
 
 UsageData.register_source_files
 
 file = UsageData::SourceFile.all.find { |f| f.basename == basename }
-raise "error: #{input_path} is not a registered source file" unless file
+raise "error: #{path} is not a registered source file" unless file
 
 used_by = file.used_by
-puts "Found #{used_by.count} files using #{basename}:"
 
-used_by.each do |file|
+filtered_used_by =
+  if method_name
+    used_by.filter { |f| f.referenced_identifiers.include? method_name }
+  else
+    used_by
+  end
+
+qualifier =
+  if method_name
+    "the #{method_name} method of "
+  else
+    ''
+  end
+
+puts "Found #{filtered_used_by.count} file(s) using #{qualifier + basename}:"
+
+filtered_used_by.each do |file|
   puts "  #{file.basename}"
 end


### PR DESCRIPTION
This PR extends the `used_by.rb` script with the ability to find all files referencing a specific method on the given script. This includes other C# scripts calling this method, in addition to any Unity scenes or prefabs containing `UnityEvent`s referencing this method.

It may return some false positives, but it should return few or no false negatives.

# Example

The basic usage of `used_by.rb` reports four files that reference the `FireBullets` script.

```bash
$ ruby used_by.rb Assets/src/FireBullets.cs
Found 4 file(s) using FireBullets.cs:
  Fire Bullets.prefab
  Turret.prefab
  MentoeHologramBulletsAttackAI.cs
  Turret.cs
```

If we want to filter these to return only methods that call the `BeginFiring` method on `FireBullets`, we can add this as an additional command-line argument.

```bash
$ ruby used_by.rb Assets/src/FireBullets.cs BeginFiring
Found 1 file(s) using the BeginFiring method of FireBullets.cs:
  Turret.cs
```

#no-test